### PR TITLE
Fix vGizmo.h include

### DIFF
--- a/imGuIZMO.quat/imGuIZMOquat.h
+++ b/imGuIZMO.quat/imGuIZMOquat.h
@@ -14,7 +14,7 @@
 #include <algorithm>
 
 
-#include <vGizmo.h>
+#include "vGizmo.h"
 
 #if !defined(IMGUIZMO_IMGUI_FOLDER)
     #define IMGUIZMO_IMGUI_FOLDER imgui/


### PR DESCRIPTION
Change include of vGizmo.h to use relative lookup.

Unrelated side note:
The source files are mixing Windows and Linux file endings. It is pretty hard to make a change without messing up the git commit history with a lot of whitespace changes. I would suggest to normalize all files to use the same line ending everywhere.